### PR TITLE
"counter" in cmd_proc() should be declared as static to persist its value across method invocations.

### DIFF
--- a/Arduino/SatNOGS.ino
+++ b/Arduino/SatNOGS.ino
@@ -154,7 +154,7 @@ void cmd_proc(int &stepAz, int &stepEl)
   char incomingByte;
   char *p=buffer;
   char *str;
-  int counter=0;
+  static int counter=0;
   char data[100];
   
   double angleAz,angleEl;


### PR DESCRIPTION
Details in the commit comment, but essentially this can sometimes cause a bug that results in some (or all) commands failing to execute. In our case it was the latter!
